### PR TITLE
cast from a negative float value to unsigned int types is undefined

### DIFF
--- a/include/can_encode_decode_inl.h
+++ b/include/can_encode_decode_inl.h
@@ -18,7 +18,7 @@ inline float toPhysicalValue(uint64_t target, float factor, float offset, bool i
 
 inline uint64_t fromPhysicalValue(float physical_value, float factor, float offset)
 {
-  return (physical_value - offset) / factor;
+  return (int64_t)((physical_value - offset) / factor);
 }
 
 inline void clearBits(uint8_t* target_byte, uint8_t* bits_to_clear, const uint8_t startbit, const uint8_t length)


### PR DESCRIPTION
The C++11 standard (ISO/IEC 9899:2011) section 6.3.1.4 "Real floating and integer" states that conversions to integer type are undefined if the value cannot be represented by the integer type.
On arm processors using a Texas Instruments compiler this line returns zero for float values outside the range of [-1, FLT_MAX+1]
Explicitly casting first to signed int is fully defined and fixes the issue.